### PR TITLE
Revert "Fix issues reported by golang-ci"

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,8 +64,4 @@ issues:
       linters: [gocritic]
 
     - path: .*_test.go
-      linters: [gosec]
-
-    - path: wal.go
-      text: "SA6002: argument should be pointer-like to avoid allocations" # TODO (review suggestion in follow up PR)
-      linters: [staticcheck]
+      linters: [ gosec ]

--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ func Example() {
 		ID:    42,
 		Point: []float32{1, 2, 3},
 	})
-	check(err)
 
 	// You might use the offset in your application or ignore it altogether.
 	fmt.Print(offset)

--- a/example_test.go
+++ b/example_test.go
@@ -59,7 +59,6 @@ func Example() {
 		ID:    42,
 		Point: []float32{1, 2, 3},
 	})
-	check(err)
 
 	// You might use the offset in your application or ignore it altogether.
 	fmt.Print(offset)

--- a/wal_test.go
+++ b/wal_test.go
@@ -18,9 +18,9 @@ func TestNew(t *testing.T) {
 	t.Run("without existing dir", func(t *testing.T) {
 		path := t.TempDir()
 		conf := wal.DefaultConfiguration()
-		w, err := wal.New(path, conf, waltest.ExampleEntries, zaptest.Logger(t))
+		wal, err := wal.New(path, conf, waltest.ExampleEntries, zaptest.Logger(t))
 		require.NoError(t, err)
-		require.NotNil(t, w)
+		require.NotNil(t, wal)
 
 		s, err := os.Stat(path)
 		require.NoError(t, err)
@@ -137,24 +137,24 @@ func TestWAL_Insert_Concurrent(t *testing.T) {
 func TestWAL_Offset(t *testing.T) {
 	path := t.TempDir()
 	conf := wal.DefaultConfiguration()
-	w, err := wal.New(path, conf, waltest.ExampleEntries, zaptest.Logger(t))
+	wal, err := wal.New(path, conf, waltest.ExampleEntries, zaptest.Logger(t))
 	require.NoError(t, err)
 
-	assert.EqualValues(t, 0, w.Offset(), "Initially, the WAL should start at offset 0")
+	assert.EqualValues(t, 0, wal.Offset(), "Initially, the WAL should start at offset 0")
 
-	writeOffset, err := w.Write(&waltest.ExampleEntry1{
+	writeOffset, err := wal.Write(&waltest.ExampleEntry1{
 		ID:    1,
 		Point: []float32{1, 2},
 	})
 	require.NoError(t, err)
-	assert.EqualValues(t, 1, w.Offset())
-	assert.Equal(t, writeOffset, w.Offset())
+	assert.EqualValues(t, 1, wal.Offset())
+	assert.Equal(t, writeOffset, wal.Offset())
 
-	writeOffset, err = w.Write(&waltest.ExampleEntry1{
+	writeOffset, err = wal.Write(&waltest.ExampleEntry1{
 		ID:    2,
 		Point: []float32{3, 4},
 	})
 	require.NoError(t, err)
-	assert.EqualValues(t, 2, w.Offset())
-	assert.Equal(t, writeOffset, w.Offset())
+	assert.EqualValues(t, 2, wal.Offset())
+	assert.Equal(t, writeOffset, wal.Offset())
 }


### PR DESCRIPTION
This reverts commit 6e37eaedd07556219e1ad7b73b67db88f56ddf40 to show-case how linting violations look like in a PR. 

**This pull request is not meant to be merged**