### PR TITLE
Remove unncessecary allocation in WAL.Write(…)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,7 +65,3 @@ issues:
 
     - path: .*_test.go
       linters: [gosec]
-
-    - path: wal.go
-      text: "SA6002: argument should be pointer-like to avoid allocations" # TODO (review suggestion in follow up PR)
-      linters: [staticcheck]


### PR DESCRIPTION
See https://github.com/dominikh/go-tools/issues/1336#issuecomment-1331206290

```
$ benchcmp BenchmarkWAL.old.txt BenchmarkWAL.new.txt 
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                old ns/op     new ns/op     delta
BenchmarkWAL_Write-8     6214          5991          -3.59%

benchmark                old allocs     new allocs     delta
BenchmarkWAL_Write-8     7              6              -14.29%

benchmark                old bytes     new bytes     delta
BenchmarkWAL_Write-8     544           520           -4.41%
```